### PR TITLE
Add error handling in render on App.js

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -15,6 +15,7 @@ export class App extends Component {
           <h1>Notez!</h1>
         </header>
         {this.props.loading && <Loading />}
+        {this.props.error && <p>{this.props.error}</p>}
         <Route exact path='/' component={CardContainer} />
         <Route exact path='/new-note' component={NewNote} />
       </div>
@@ -23,11 +24,13 @@ export class App extends Component {
 }
 
 App.propTypes = {
-  loading: PropTypes.bool.isRequired
+  loading: PropTypes.bool.isRequired,
+  error: PropTypes.string.isRequired
 };
 
 export const mapStateToProps = (state) => ({
   loading: state.isLoading,
+  error: state.error
 });
 
 export default connect(mapStateToProps)(App);


### PR DESCRIPTION
### Changes made:

- added 'error' to mSTP
- added error handling to conditionally render if there is an error message in store
- updated propTypes
- verified that App.test.js is still passing